### PR TITLE
Namespace change and Label HtmlHelper enhancement

### DIFF
--- a/Nancy.ViewEngines.Razor.HtmlHelpers.TestApp/Program.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers.TestApp/Program.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Nancy.Hosting.Self;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers.TestApp
+namespace Nancy.ViewEngines.Razor.TestApp
 {
     public class Program
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers.TestApp/Properties/AssemblyInfo.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers.TestApp/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Nancy.ViewEngines.Razor.HtmlHelpers.TestApp")]
+[assembly: AssemblyTitle("Nancy.ViewEngines.Razor.TestApp")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Nancy.ViewEngines.Razor.HtmlHelpers.TestApp")]
+[assembly: AssemblyProduct("Nancy.ViewEngines.Razor.TestApp")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/HtmlHelpersSelectExtensionsFixture.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/HtmlHelpersSelectExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.ViewEngines.Razor.HtmlHelpers.Tests
+﻿namespace Nancy.ViewEngines.Razor.Tests
 {
     using Xunit;
 

--- a/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/Properties/AssemblyInfo.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Nancy.ViewEngines.Razor.HtmlHelpers.Tests")]
+[assembly: AssemblyTitle("Nancy.ViewEngines.Razor.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Nancy.ViewEngines.Razor.HtmlHelpers.Tests")]
+[assembly: AssemblyProduct("Nancy.ViewEngines.Razor.Tests")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/SelectListItemExtensionsFixture.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers.Tests/SelectListItemExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.ViewEngines.Razor.HtmlHelpers.Tests
+﻿namespace Nancy.ViewEngines.Razor.Tests
 {
     using Xunit;
     using System.Linq;

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelperInputExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelperInputExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data.Linq;
 using System.Linq.Expressions;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelperInputExtensions
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersCheckBoxExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersCheckBoxExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelpersCheckBoxExtensions
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersLabelExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersLabelExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using Nancy.Helpers;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelpersLabelExtensions
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersLabelExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersLabelExtensions.cs
@@ -9,17 +9,17 @@ namespace Nancy.ViewEngines.Razor
     {
         public static IHtmlString LabelFor<TModel, TProperty>(this HtmlHelpers<TModel> helper, Expression<Func<TModel, TProperty>> expression)
         {
-            return Label(helper, ExpressionHelper.GetExpressionText(expression));
+            return Label(helper, ExpressionHelper.GetExpessionDisplayName(expression), ExpressionHelper.GetExpressionText(expression));
         }
 
         public static IHtmlString LabelFor<TModel, TProperty>(this HtmlHelpers<TModel> helper, Expression<Func<TModel, TProperty>> expression, object htmlAttributes)
         {
-            return Label(helper, ExpressionHelper.GetExpressionText(expression), htmlAttributes);
+            return Label(helper, ExpressionHelper.GetExpessionDisplayName(expression), ExpressionHelper.GetExpressionText(expression), htmlAttributes);
         }
 
         public static IHtmlString LabelFor<TModel, TProperty>(this HtmlHelpers<TModel> helper, Expression<Func<TModel, TProperty>> expression, IDictionary<string, object> htmlAttributes)
         {
-            return Label(helper, ExpressionHelper.GetExpressionText(expression), TypeHelper.ObjectToDictionary(htmlAttributes));
+            return Label(helper, ExpressionHelper.GetExpessionDisplayName(expression), ExpressionHelper.GetExpressionText(expression), TypeHelper.ObjectToDictionary(htmlAttributes));
         }
 
         public static IHtmlString Label<TModel>(this HtmlHelpers<TModel> helper, string labelText)

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersRadioExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersRadioExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelpersRadioExtensions
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersSelectExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersSelectExtensions.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 using System.Text;
 using Nancy.Helpers;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelper
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersTextAreaExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlHelpersTextAreaExtensions.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq.Expressions;
 using Nancy.Helpers;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class HtmlHelpersTextAreaExtensions
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlString.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/HtmlString.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.ViewEngines.Razor.HtmlHelpers
+﻿namespace Nancy.ViewEngines.Razor
 {
     public class HtmlString : NonEncodedHtmlString
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/ModelMetadata.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/ModelMetadata.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public class ModelMetadata
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/CachedExpressionCompiler.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/CachedExpressionCompiler.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     internal static class CachedExpressionCompiler
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/ExpressionHelper.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/ExpressionHelper.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class ExpressionHelper
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/ExpressionHelper.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/ExpressionHelper.cs
@@ -9,6 +9,77 @@ namespace Nancy.ViewEngines.Razor
 {
     public static class ExpressionHelper
     {
+        public static string GetExpessionDisplayName(LambdaExpression expression)
+        {
+            // Split apart the expression string for property/field accessors to create its name
+            var nameParts = new Stack<string>();
+            var part = expression.Body;
+
+            while (part != null)
+            {
+                if (part.NodeType == ExpressionType.Call)
+                {
+                    var methodExpression = (MethodCallExpression)part;
+
+                    if (!IsSingleArgumentIndexer(methodExpression))
+                    {
+                        break;
+                    }
+
+                    nameParts.Push(GetIndexerInvocation(methodExpression.Arguments.Single(), expression.Parameters.ToArray()));
+                    part = methodExpression.Object;
+                }
+                else if (part.NodeType == ExpressionType.ArrayIndex)
+                {
+                    var binaryExpression = (BinaryExpression)part;
+                    nameParts.Push(GetIndexerInvocation(binaryExpression.Right, expression.Parameters.ToArray()));
+                    part = binaryExpression.Left;
+                }
+                else if (part.NodeType == ExpressionType.MemberAccess)
+                {
+                    var memberExpressionPart = (MemberExpression)part;
+
+                    var displayName = memberExpressionPart.Member.GetCustomAttribute<System.ComponentModel.DisplayNameAttribute>();
+                    if (displayName != null)
+                    {
+                        nameParts.Clear();
+                        nameParts.Push(displayName.DisplayName);
+                    }
+                    else
+                    {
+                        nameParts.Push("." + memberExpressionPart.Member.Name);
+                    }
+                    part = memberExpressionPart.Expression;
+                }
+                else if (part.NodeType == ExpressionType.Parameter)
+                {
+                    // Dev10 Bug #907611
+                    // When the expression is parameter based (m => m.Something...), we'll push an empty
+                    // string onto the stack and stop evaluating. The extra empty string makes sure that
+                    // we don't accidentally cut off too much of m => m.Model.
+                    nameParts.Push(String.Empty);
+                    part = null;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            // If it starts with "model", then strip that away
+            if (nameParts.Count > 0 && String.Equals(nameParts.Peek(), ".model", StringComparison.OrdinalIgnoreCase))
+            {
+                nameParts.Pop();
+            }
+
+            if (nameParts.Count > 0)
+            {
+                return nameParts.Aggregate((left, right) => left + right).TrimStart('.');
+            }
+
+            return String.Empty;
+        }
+
         public static string GetExpressionText(string expression)
         {
             return

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/InputType.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/InputType.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.ViewEngines.Razor.HtmlHelpers
+﻿namespace Nancy.ViewEngines.Razor
 {
     public enum InputType
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/TagBuilder.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/TagBuilder.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Text;
 using Nancy.Helpers;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public class TagBuilder
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/TypeHelper.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/MvcBits/TypeHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class TypeHelper
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/Properties/AssemblyInfo.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/Properties/AssemblyInfo.cs
@@ -1,11 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("Nancy.ViewEngines.Razor.HtmlHelpers")]
+[assembly: AssemblyTitle("Nancy.ViewEngines.Razor")]
 [assembly: AssemblyDescription("HTML Helpers for #NancyFx's Razor implementation")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("David Whitney")]
-[assembly: AssemblyProduct("Nancy.ViewEngines.Razor.HtmlHelpers")]
+[assembly: AssemblyProduct("Nancy.ViewEngines.Razor")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/RouteValueDictionary.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/RouteValueDictionary.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public class RouteValueDictionary : Dictionary<string, object>
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/SelectListItem.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/SelectListItem.cs
@@ -1,4 +1,4 @@
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public class SelectListItem
     {

--- a/Nancy.ViewEngines.Razor.HtmlHelpers/SelectListItemExtensions.cs
+++ b/Nancy.ViewEngines.Razor.HtmlHelpers/SelectListItemExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Nancy.ViewEngines.Razor.HtmlHelpers
+namespace Nancy.ViewEngines.Razor
 {
     public static class SelectListItemExtensions
     {


### PR DESCRIPTION
Hi! Thanks so much for doing the heavy lifting getting this project up and running!
We're using this code in our Nancy+Razor project and I noticed some weirdness with Intellisense that appeared to be related to a namespace collision. There's a class in the 1.2 Nancy.ViewEngines.Razor assembly named Nancy.ViewEngines.Razor.HtmlHelpers, which conflicts with your Nancy.ViewEngines.Razor.HtmlHelpers namespace and makes Intellisense terribly unhappy.
While I was in there, I also added some code to have the LabelFor extensions use the DisplayName attribute if it is detected.
